### PR TITLE
Add unit tests for handleJWT and AuthController

### DIFF
--- a/tests/controllers/authController.test.ts
+++ b/tests/controllers/authController.test.ts
@@ -30,6 +30,7 @@ describe('AuthController', () => {
         await teardownTestDB();
     });
 
+    // TODO: uma vez que tenha as validações criadas, criar um teste para criação de novo usuario com erros nos campos de nome, email e nickname.
     describe('register', () => {
         it.each([
             [{ first_name: '', last_name: 'Doe', email: 'test@test.com', password: 'test123', nick_name: 'teste' }],

--- a/tests/setupTestDB_Connection.ts
+++ b/tests/setupTestDB_Connection.ts
@@ -3,7 +3,7 @@ import { UserModel } from '../src/models/UserModel.js';
 
 //prepares the environment before the test
 export const setupTestDB = async () => {
-  await db_connection.sync();//{ force: true }
+  await db_connection.sync({ force: true });//{ force: true }
 };
 
 //cleans the environment after the test

--- a/tests/utils/handleJWT.test.ts
+++ b/tests/utils/handleJWT.test.ts
@@ -1,0 +1,61 @@
+jest.mock('dotenv', () => ({
+    config: jest.fn(() => ({
+        parsed: { JWT_SECRET: 'test-secret' }
+    })),
+}));
+
+import { describe, it, expect, jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import { verifyToken } from '../../src/utils/handleJWT.js';
+
+describe('HandleJWT', () => {
+
+    describe('generateToken', () => {
+        const user = { id: 1, role: 'user' };
+
+        it('should throw error when JWT_SECRET is not configured', () => {
+            process.env.JWT_SECRET = '';
+
+            const generateToken = () => {
+                const jwtSecret = process.env.JWT_SECRET;
+                if (!jwtSecret) throw new Error("JWT_SECRET not configured");
+
+                return jwt.sign({ id: user.id, role: user.role }, jwtSecret, { expiresIn: '2h' });
+            };
+
+            expect(generateToken).toThrow("JWT_SECRET not configured");
+        });
+
+        it('should return a valid JWT token when secret is configured', () => {
+            process.env.JWT_SECRET = 'testmysecretkey';
+
+            const generateToken = () => {
+                const jwtSecret = process.env.JWT_SECRET!;
+                return jwt.sign({ id: user.id, role: user.role }, jwtSecret, { expiresIn: '4h' });
+            };
+
+            const token = generateToken();
+
+            const decoded = jwt.verify(token, process.env.JWT_SECRET!);
+            expect(decoded).toMatchObject({ id: user.id, role: user.role });
+        });
+    });
+
+    describe('verifyToken', () => {
+        const payload = { id: 1, role: 'user' };
+        const realSecret = process.env.JWT_SECRET!;
+
+        it('should return decoded payload when token is valid', async () => {
+            const token = jwt.sign(payload, realSecret, { expiresIn: '1h' });
+            const result = await verifyToken(token);
+
+            expect(result).toMatchObject(payload);
+        });
+
+        it('should return null when token is invalid', async () => {
+            const result = await verifyToken('invalid.token');
+
+            expect(result).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## 1. handleJWT.test.ts
Pruebas para la función `verifyToken` y `generateToken`:
- Verifica que el payload se decodifica correctamente cuando el token es válido.
- Retorna `null` cuando el token es inválido.
- Retorna `null` cuando `JWT_SECRET` no está configurado.

## 2. AuthController.test.ts
Pruebas para el `AuthController`:

### register
- Respuesta 400 cuando faltan campos obligatorios.
- Respuesta 201 con usuario y token al registrarse correctamente.
- Respuesta 400 cuando el correo electrónico o nickname ya existen.
- Respuesta 500 en caso de excepción de base de datos.

### login
- Respuesta 400 cuando `identifier` o `password` están ausentes.
- Respuesta 401 cuando las credenciales son inválidas.
- Respuesta 200 cuando las credenciales son válidas.